### PR TITLE
Fix mrr is broken on Windows

### DIFF
--- a/autoload/mr/mrr.vim
+++ b/autoload/mr/mrr.vim
@@ -29,9 +29,10 @@ function! mr#mrr#delete(filename) abort
 endfunction
 
 function! s:record(path) abort
-  let path = fnamemodify(a:path, ':p')
-  let path = finddir('.git/..', path . ';')
+  let path = fnamemodify(a:path, ':p:h')
+  let path = finddir('.git', path . ';')
   if path !=# ''
+    let path = fnamemodify(path, ':p:h:h')
     call s:mrr.record(path)
   endif
 endfunction


### PR DESCRIPTION
mrr is broken on Windows because `finddir('.git/..', ...)` is platform-dependent.
I fixed that by using `fnamemodify()` to get the parent directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved path normalization and Git directory detection to ensure more accurate recording root identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->